### PR TITLE
Email standart regex

### DIFF
--- a/swift-base/Extensions/StringExtension.swift
+++ b/swift-base/Extensions/StringExtension.swift
@@ -13,8 +13,9 @@ extension String {
     return self.characters.count
   }
   
+  //Regex fulfill RFC 5322 Internet Message format
   func isEmailFormatted() -> Bool {
-    let predicate = NSPredicate(format: "SELF MATCHES %@", "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,4}")
+    let predicate = NSPredicate(format: "SELF MATCHES %@", "[A-Za-z0-9!#$%&'*+/=?^_`{|}~-]+(\\.[A-Za-z0-9!#$%&'*+/=?^_`{|}~-]+)*@([A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?\\.)+[A-Za-z0-9]([A-Za-z0-9-]*[A-Za-z0-9])?")
     return predicate.evaluateWithObject(self)
   }
 }


### PR DESCRIPTION
Email validation changed to fulfill RFC 5322 Internet Message format.
-Avoid successive periods.
-Avoid hyphens at domain/subdomain ends.
-Allows multiple subdomains.
-Allows long top-level domains. 
