### PR TITLE
Fixed session saving issue

### DIFF
--- a/AcceptanceTests/Tests/aSignInTests.swift
+++ b/AcceptanceTests/Tests/aSignInTests.swift
@@ -75,8 +75,8 @@ class aSignInTests: KIFTestCase {
       return fixture(filePath: stubPath!, status: 200, headers: ["Content-Type": "application/json", "uid": ""]).requestTime(0, responseTime: OHHTTPStubsDownloadSpeedWifi)
     }
     
-    tester().enterText("username", intoViewWithAccessibilityIdentifier: "UsernameTextField")
-    tester().enterText("password", intoViewWithAccessibilityIdentifier: "PasswordTextField")
+    tester().enterText("rootstrap@gmail.com", intoViewWithAccessibilityIdentifier: "UsernameTextField")
+    tester().enterText("123456789", intoViewWithAccessibilityIdentifier: "PasswordTextField")
     tester().tapView(withAccessibilityIdentifier: "SignInButton")
     tester().waitForView(withAccessibilityIdentifier: "AfterLoginSignupView")
     XCTAssertEqual(SessionDataManager.checkSession(), true)

--- a/ios-base/Extensions/DictionaryExtension.swift
+++ b/ios-base/Extensions/DictionaryExtension.swift
@@ -21,3 +21,13 @@ func + <K, V> (left: [K: V], right: [K: V]) -> [K: V] {
 func += <K, V> (left: inout [K: V], right: [K: V]) {
   left += right
 }
+
+extension Dictionary where Key: ExpressibleByStringLiteral {
+  mutating func lowercaseKeys() {
+    for key in self.keys {
+      if let loweredKey = String(describing: key).lowercased() as? Key {
+        self[loweredKey] = self.removeValue(forKey: key)
+      }
+    }
+  }
+}

--- a/ios-base/Models/Session.swift
+++ b/ios-base/Models/Session.swift
@@ -34,4 +34,23 @@ class Session: NSObject, NSCoding {
     aCoder.encode(self.accessToken, forKey: "session-token")
     aCoder.encode(self.expiry, forKey: "session-expiry")
   }
+  
+  // MARK: - Parser
+  class func parse(from headers: [String: Any]) -> Session {
+    var loweredHeaders = headers
+    loweredHeaders.lowercaseKeys()
+    var expiry: Date?
+    if let loweredHeaders = loweredHeaders as? [String: String] {
+      if let expiryString = loweredHeaders[APIClient.HTTPHeader.expiry.rawValue],
+         let expiryNumber = Double(expiryString) {
+        expiry = Date(timeIntervalSince1970: expiryNumber)
+      }
+      return Session(uid:     loweredHeaders[APIClient.HTTPHeader.uid.rawValue],
+                     client:  loweredHeaders[APIClient.HTTPHeader.client.rawValue],
+                     token:   loweredHeaders[APIClient.HTTPHeader.token.rawValue],
+                     expires: expiry
+      )
+    }
+    return Session()
+  }
 }

--- a/ios-base/Networking/Services/UserAPI.swift
+++ b/ios-base/Networking/Services/UserAPI.swift
@@ -14,7 +14,7 @@ class UserAPI {
   fileprivate static let usersUrl = "/users/"
   fileprivate static let currentUserUrl = "/user/"
 
-  class func login(_ email: String, password: String, success: @escaping (_ responseObject: String?) -> Void, failure: @escaping (_ error: Error) -> Void) {
+  class func login(_ email: String, password: String, success: @escaping () -> Void, failure: @escaping (_ error: Error) -> Void) {
     let url = usersUrl + "sign_in"
     let parameters = [
       "user": [
@@ -22,13 +22,15 @@ class UserAPI {
         "password": password
       ]
     ]
-    APIClient.sendPostRequest(url, params: parameters as [String : AnyObject]?,
-      success: { response in
-        let json = JSON(response)
-        UserDataManager.storeUserObject(User.parse(fromJSON: json))
-        success("")
+    APIClient.sendPostRequest(url, params: parameters as [String : AnyObject]?, success: { response, headers in
+      let json = JSON(response)
+      UserDataManager.storeUserObject(User.parse(fromJSON: json))
+      if let headers = headers as? [String: Any] {
+        SessionDataManager.storeSessionObject(Session.parse(from: headers))
+      }
+      success()
     }, failure: { error in
-        failure(error)
+      failure(error)
     })
   }
 
@@ -46,7 +48,12 @@ class UserAPI {
     let image = MultipartMedia(key: "user[avatar]", data: picData)
     //Mixed base64 encoded and multipart images are supported in [MultipartMedia] param:
     //Example: let image2 = Base64Media(key: "user[image]", data: picData) Then: media [image, image2]
-    APIClient.sendMultipartRequest(url: usersUrl, params: parameters, paramsRootKey: "", media: [image], success: { (response) in
+    APIClient.sendMultipartRequest(url: usersUrl, params: parameters, paramsRootKey: "", media: [image], success: { response, headers in
+      let responseJson = JSON(response)
+      UserDataManager.storeUserObject(User.parse(fromJSON: responseJson))
+      if let headers = headers as? [String: Any] {
+        SessionDataManager.storeSessionObject(Session.parse(from: headers))
+      }
       success(response)
     }, failure: { (error) in
       failure(error)
@@ -65,11 +72,13 @@ class UserAPI {
       ]
     ]
     
-    APIClient.sendPostRequest(usersUrl, params: parameters as [String : AnyObject]?,
-                              success: { response in
-                                let json = JSON(response)
-                                UserDataManager.storeUserObject(User.parse(fromJSON: json))
-                                success(response)
+    APIClient.sendPostRequest(usersUrl, params: parameters as [String : AnyObject]?, success: { response, headers in
+      let responseJson = JSON(response)
+      UserDataManager.storeUserObject(User.parse(fromJSON: responseJson))
+      if let headers = headers as? [String: Any] {
+        SessionDataManager.storeSessionObject(Session.parse(from: headers))
+      }
+      success(response)
     }, failure: { error in
       failure(error)
     })
@@ -90,11 +99,13 @@ class UserAPI {
     let parameters = [
       "access_token": token
       ] as [String : Any]
-    APIClient.sendPostRequest(url, params: parameters as [String : AnyObject]?,
-      success: { responseObject in
-        let json = JSON(responseObject)
-        UserDataManager.storeUserObject(User.parse(fromJSON: json))
-        success()
+    APIClient.sendPostRequest(url, params: parameters as [String : AnyObject]?, success: { responseObject, headers in
+      let json = JSON(responseObject)
+      UserDataManager.storeUserObject(User.parse(fromJSON: json))
+      if let headers = headers as? [String: Any] {
+        SessionDataManager.storeSessionObject(Session.parse(from: headers))
+      }
+      success()
     }, failure: { error in
       failure(error)
     })

--- a/ios-base/ViewControllers/SignInViewController.swift
+++ b/ios-base/ViewControllers/SignInViewController.swift
@@ -28,10 +28,10 @@ class SignInViewController: UIViewController {
   // MARK: - Actions
   @IBAction func tapOnSignInButton(_ sender: Any) {
     UIApplication.showNetworkActivity()
-    let email = emailField.text ?? "rootstrap@gmail.com"
-    let password = passwordField.text ?? "123456789"
+    let email = !emailField.text!.isEmpty ? emailField.text : "rootstrap@gmail.com"
+    let password = !passwordField.text!.isEmpty ? passwordField.text : "123456789"
     
-    UserAPI.login(email, password: password, success: { _ in
+    UserAPI.login(email!, password: password!, success: { _ in
       UIApplication.hideNetworkActivity()
       UIApplication.shared.keyWindow?.rootViewController = self.storyboard?.instantiateViewController(withIdentifier: "HomeViewController")
     }, failure: { error in

--- a/ios-base/ViewControllers/SignUpViewController.swift
+++ b/ios-base/ViewControllers/SignUpViewController.swift
@@ -28,10 +28,10 @@ class SignUpViewController: UIViewController {
   // MARK: - Actions
   @IBAction func tapOnSignUpButton(_ sender: Any) {
     UIApplication.showNetworkActivity()
-    let email = emailField.text ?? "\(randomName())@gmail.com"
-    let password = passwordField.text ?? "123456789"
+    let email = !emailField.text!.isEmpty ? emailField.text : "\(randomName())@gmail.com"
+    let password = !passwordField.text!.isEmpty ? passwordField.text : "123456789"
     
-    UserAPI.signup(email, password: password, avatar64: randomImage(), success: { (_) in
+    UserAPI.signup(email!, password: password!, avatar64: randomImage(), success: { (_) in
       UIApplication.hideNetworkActivity()
       UIApplication.shared.keyWindow?.rootViewController = self.storyboard?.instantiateViewController(withIdentifier: "HomeViewController")
     }, failure: { error in


### PR DESCRIPTION
This PR fixes the [session saving issue](https://github.com/rootstrap/ios-base/issues/58).
The session now needs to be stored on sign in and up and not with each response of any request.
That's why `updateSessionData` was removed and the headers are now accesible from the different network methods allowing the session to be stored specifically in the `signUp` and `logIn` methods.