### PR TITLE
Fixed error parsing for old keys

### DIFF
--- a/ios-base/Base.lproj/Main.storyboard
+++ b/ios-base/Base.lproj/Main.storyboard
@@ -158,7 +158,7 @@ RS iOS BASE.</string>
                                 </constraints>
                                 <nil key="textColor"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits" autocorrectionType="no" keyboardType="emailAddress" textContentType="email"/>
+                                <textInputTraits key="textInputTraits" autocorrectionType="no" keyboardType="emailAddress" returnKeyType="next" textContentType="email"/>
                             </textField>
                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="line" placeholder="Password" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="VXP-E8-PA8">
                                 <rect key="frame" x="32" y="347.5" width="311" height="40"/>
@@ -292,7 +292,7 @@ RS iOS BASE.</string>
                                 </constraints>
                                 <nil key="textColor"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits"/>
+                                <textInputTraits key="textInputTraits" keyboardType="namePhonePad" returnKeyType="next" textContentType="name"/>
                             </textField>
                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="line" placeholder="Email" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="xYV-eE-Ila">
                                 <rect key="frame" x="32" y="258.5" width="311" height="40"/>
@@ -314,7 +314,7 @@ RS iOS BASE.</string>
                                 </constraints>
                                 <nil key="textColor"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits" secureTextEntry="YES"/>
+                                <textInputTraits key="textInputTraits" secureTextEntry="YES" textContentType="password"/>
                             </textField>
                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="line" placeholder="Confirm Password" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="v9r-co-4vM">
                                 <rect key="frame" x="32" y="378.5" width="311" height="40"/>

--- a/ios-base/Networking/APIClient.swift
+++ b/ios-base/Networking/APIClient.swift
@@ -168,8 +168,8 @@ class APIClient {
     if let messageDict = dictionary["errors"] as? [String: [String]] {
       let errorsList = messageDict[messageDict.keys.first!]!
       return NSError(domain: "\(messageDict.keys.first!) \(errorsList.first!)", code: code ?? 500, userInfo: nil)
-    } else if let errors = dictionary["errors"] as? [String] {
-      return NSError(domain: errors[0], code:code ?? 500, userInfo: nil)
+    } else if let error = dictionary["error"] as? String {
+      return NSError(domain: error, code: code ?? 500, userInfo: nil)
     } else if let errors = dictionary["errors"] as? [String: Any] {
       let errorDesc = errors[errors.keys.first!]!
       return NSError(domain: "\(errors.keys.first!) " + "\(errorDesc)", code:code ?? 500, userInfo: nil)


### PR DESCRIPTION
1. Fixed parsing of errors and changed to new key 'error' used in rails-base.

2. Added custom keyboard types for some UITextFields.

Solves #69 

To be merged with https://github.com/rootstrap/rails_api_base/pull/107