### PR TITLE
Added Navigators to handle navigation programatically

### DIFF
--- a/AcceptanceTests/Tests/LogoutTests.swift
+++ b/AcceptanceTests/Tests/LogoutTests.swift
@@ -16,10 +16,7 @@ class LogoutTests: KIFTestCase {
     super.beforeAll()
     
     SessionManager.currentSession = Session(uid: "rootstrap@gmail.com", client: "client", token: "token", expires: Date(timeIntervalSinceNow: 3.15576E+07)) //Simulates the login
-    if let navigationController = UIApplication.shared.keyWindow?.rootViewController as? UINavigationController,
-      let vc = navigationController.storyboard?.instantiateViewController(withIdentifier: "HomeViewController") {
-      navigationController.pushViewController(vc, animated: true)
-    }
+    AppNavigator.shared.navigate(to: HomeRoutes.home, with: .changeRoot, animated: false)
   }
   
   override func beforeEach() {
@@ -31,9 +28,7 @@ class LogoutTests: KIFTestCase {
   override func afterAll() {
     super.afterAll()
     
-    if let navigationController = UIApplication.shared.keyWindow?.rootViewController as? UINavigationController {
-      navigationController.popToRootViewController(animated: true)
-    }
+    AppNavigator.shared.navigate(to: OnboardingRoutes.firstScreen, with: .changeRoot, animated: false)
   }
   
   // MARK: - Tests

--- a/AcceptanceTests/Tests/SignInTests.swift
+++ b/AcceptanceTests/Tests/SignInTests.swift
@@ -16,11 +16,9 @@ class SignInTests: KIFTestCase {
   
   override func beforeEach() {
     super.beforeEach()
-
-    if let navigationController = UIApplication.shared.keyWindow?.rootViewController as? UINavigationController {
-      navigationController.popViewController(animated: true)
-    }
     
+    AppNavigator.shared.pop()
+
     tester().waitForView(withAccessibilityIdentifier: "StartView")
     tester().tapView(withAccessibilityIdentifier: "GoToSignInButton")
     tester().waitForView(withAccessibilityIdentifier: "SignInView")
@@ -30,17 +28,14 @@ class SignInTests: KIFTestCase {
     super.afterEach()
 
     SessionManager.deleteSession()
-    if let navigationController = UIApplication.shared.keyWindow?.rootViewController as? UINavigationController {
-      navigationController.popToRootViewController(animated: true)
-    }
+    AppNavigator.shared.navigate(to: OnboardingRoutes.firstScreen, with: .changeRoot, animated: false)
   }
-  
+
   override func afterAll() {
     super.afterAll()
-    
-    UIApplication.shared.keyWindow?.rootViewController = UIStoryboard(name: "Main", bundle: nil).instantiateInitialViewController()
+    AppNavigator.shared.navigate(to: OnboardingRoutes.firstScreen, with: .changeRoot, animated: false)
   }
-  
+
   // MARK: - Tests
   
   func testSignInFormValidation() {

--- a/AcceptanceTests/Tests/SignInTests.swift
+++ b/AcceptanceTests/Tests/SignInTests.swift
@@ -28,7 +28,7 @@ class SignInTests: KIFTestCase {
     super.afterEach()
 
     SessionManager.deleteSession()
-    AppNavigator.shared.navigate(to: OnboardingRoutes.firstScreen, with: .changeRoot, animated: false)
+    AppNavigator.shared.popToRoot()
   }
 
   override func afterAll() {

--- a/AcceptanceTests/Tests/SignUpTests.swift
+++ b/AcceptanceTests/Tests/SignUpTests.swift
@@ -25,20 +25,14 @@ class SignUpTests: KIFTestCase {
   override func afterEach() {
     super.afterEach()
     
-    if let navigationController = UIApplication.shared.keyWindow?.rootViewController as? UINavigationController, !SessionManager.validSession {
-      navigationController.popViewController(animated: true)
-    }
+    AppNavigator.shared.pop()
   }
   
   override func afterAll() {
     super.afterAll()
     
     SessionManager.deleteSession()
-    if let navigationController = UIApplication.shared.keyWindow?.rootViewController as? UINavigationController {
-      navigationController.popToRootViewController(animated: true)
-    }
-    
-    UIApplication.shared.keyWindow?.rootViewController = UIStoryboard(name: "Main", bundle: nil).instantiateInitialViewController()
+    AppNavigator.shared.navigate(to: OnboardingRoutes.firstScreen, with: .changeRoot, animated: false)
   }
   
   // MARK: - Tests

--- a/ios-base.xcodeproj/project.pbxproj
+++ b/ios-base.xcodeproj/project.pbxproj
@@ -42,6 +42,8 @@
 		9BE3669D1F101737007CAECD /* MultipartMedia.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BE3669C1F101736007CAECD /* MultipartMedia.swift */; };
 		9BE3669F1F10175E007CAECD /* Base64Media.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BE3669E1F10175E007CAECD /* Base64Media.swift */; };
 		9BFA84F31C776827009F64E4 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9BFA84F21C776827009F64E4 /* LaunchScreen.storyboard */; };
+		B886FBA8E9E79013B5A50888 /* Pods_AcceptanceTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CAD50CF945C0577C5D464B48 /* Pods_AcceptanceTests.framework */; };
+		C97486FDF4DD33D6425EB497 /* Pods_ios_base.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AB8D84D08CE7E8109E57D429 /* Pods_ios_base.framework */; };
 		E81171921DE5EFB7003D3DF5 /* UIViewControllerExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E81171911DE5EFB7003D3DF5 /* UIViewControllerExtension.swift */; };
 		E8290BFE1D832D9200599960 /* UIViewExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8290BFD1D832D9200599960 /* UIViewExtension.swift */; };
 		E8290C021D8330A800599960 /* StringExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8290C011D8330A800599960 /* StringExtension.swift */; };
@@ -51,6 +53,11 @@
 		FA54D5881E11C59600F0DBEA /* FirstViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA54D5871E11C59600F0DBEA /* FirstViewController.swift */; };
 		FABDC9221EE1EB2B000DDAC3 /* ConfigurationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FABDC9211EE1EB2B000DDAC3 /* ConfigurationManager.swift */; };
 		FE251D0722A7FE0F00E0DE90 /* DataExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE251D0622A7FE0F00E0DE90 /* DataExtension.swift */; };
+		FE4D635C22B2C75400685161 /* Navigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE4D635B22B2C75400685161 /* Navigator.swift */; };
+		FE4D635E22B2CAFF00685161 /* AppNavigator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE4D635D22B2CAFF00685161 /* AppNavigator.swift */; };
+		FE4D636022B2CB3800685161 /* HomeRoutes.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE4D635F22B2CB3800685161 /* HomeRoutes.swift */; };
+		FE4D636222B2CBB000685161 /* OnboardingRoutes.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE4D636122B2CBB000685161 /* OnboardingRoutes.swift */; };
+		FE4D636422B2CDF700685161 /* ViewModelState.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE4D636322B2CDF700685161 /* ViewModelState.swift */; };
 		FE583F0A22AFC9E000EF3CDA /* AnalyticsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE583F0922AFC9E000EF3CDA /* AnalyticsManager.swift */; };
 		FE583F0C22AFC9EA00EF3CDA /* AnalyticsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE583F0B22AFC9EA00EF3CDA /* AnalyticsService.swift */; };
 		FE583F0E22AFC9F300EF3CDA /* FirebaseAnalyticsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE583F0D22AFC9F300EF3CDA /* FirebaseAnalyticsService.swift */; };
@@ -79,6 +86,8 @@
 		0ABFB8911FA366D90098F751 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		0ABFB8941FA366EA0098F751 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Main.strings; sourceTree = "<group>"; };
 		0ABFB8961FA366EC0098F751 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Main.strings; sourceTree = "<group>"; };
+		21E8D96E1DA981F8FCCFCA2F /* Pods-AcceptanceTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AcceptanceTests.debug.xcconfig"; path = "Target Support Files/Pods-AcceptanceTests/Pods-AcceptanceTests.debug.xcconfig"; sourceTree = "<group>"; };
+		30ACA6104514E285F2B715F4 /* Pods-ios-base.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ios-base.release.xcconfig"; path = "Target Support Files/Pods-ios-base/Pods-ios-base.release.xcconfig"; sourceTree = "<group>"; };
 		9B0C72691C738D3400BAF3B1 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; tabWidth = 2; };
 		9B0C726A1C738D3400BAF3B1 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		9B0C726D1C738D3400BAF3B1 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -116,15 +125,26 @@
 		9BE3669C1F101736007CAECD /* MultipartMedia.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MultipartMedia.swift; sourceTree = "<group>"; };
 		9BE3669E1F10175E007CAECD /* Base64Media.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Base64Media.swift; sourceTree = "<group>"; };
 		9BFA84F21C776827009F64E4 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
+		A902D431CC715BF283E3AFB2 /* Pods-ios-base.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ios-base.debug.xcconfig"; path = "Target Support Files/Pods-ios-base/Pods-ios-base.debug.xcconfig"; sourceTree = "<group>"; };
+		AB8D84D08CE7E8109E57D429 /* Pods_ios_base.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ios_base.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		CAD50CF945C0577C5D464B48 /* Pods_AcceptanceTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AcceptanceTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		CF081D39C34A81D13D22BBB6 /* Pods-AcceptanceTests.staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AcceptanceTests.staging.xcconfig"; path = "Target Support Files/Pods-AcceptanceTests/Pods-AcceptanceTests.staging.xcconfig"; sourceTree = "<group>"; };
+		E263A8A07D838EC4E08EEAA8 /* Pods-AcceptanceTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AcceptanceTests.release.xcconfig"; path = "Target Support Files/Pods-AcceptanceTests/Pods-AcceptanceTests.release.xcconfig"; sourceTree = "<group>"; };
 		E81171911DE5EFB7003D3DF5 /* UIViewControllerExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = UIViewControllerExtension.swift; sourceTree = "<group>"; tabWidth = 2; };
 		E8290BFD1D832D9200599960 /* UIViewExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = UIViewExtension.swift; sourceTree = "<group>"; tabWidth = 2; };
 		E8290C011D8330A800599960 /* StringExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = StringExtension.swift; sourceTree = "<group>"; tabWidth = 2; };
 		E8B30E011E72FF8000131DCF /* UIStoryboardExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIStoryboardExtension.swift; sourceTree = "<group>"; };
 		E8FBB1BE1DD21A32000D6740 /* Session.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Session.swift; sourceTree = "<group>"; };
 		E8FBB1C01DD21D18000D6740 /* SessionManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionManager.swift; sourceTree = "<group>"; };
+		ED0AC0190D101803F661CBAE /* Pods-ios-base.staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ios-base.staging.xcconfig"; path = "Target Support Files/Pods-ios-base/Pods-ios-base.staging.xcconfig"; sourceTree = "<group>"; };
 		FA54D5871E11C59600F0DBEA /* FirstViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = FirstViewController.swift; sourceTree = "<group>"; tabWidth = 2; };
 		FABDC9211EE1EB2B000DDAC3 /* ConfigurationManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConfigurationManager.swift; sourceTree = "<group>"; };
 		FE251D0622A7FE0F00E0DE90 /* DataExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataExtension.swift; sourceTree = "<group>"; };
+		FE4D635B22B2C75400685161 /* Navigator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Navigator.swift; sourceTree = "<group>"; };
+		FE4D635D22B2CAFF00685161 /* AppNavigator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppNavigator.swift; sourceTree = "<group>"; };
+		FE4D635F22B2CB3800685161 /* HomeRoutes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeRoutes.swift; sourceTree = "<group>"; };
+		FE4D636122B2CBB000685161 /* OnboardingRoutes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingRoutes.swift; sourceTree = "<group>"; };
+		FE4D636322B2CDF700685161 /* ViewModelState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelState.swift; sourceTree = "<group>"; };
 		FE583F0922AFC9E000EF3CDA /* AnalyticsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsManager.swift; sourceTree = "<group>"; };
 		FE583F0B22AFC9EA00EF3CDA /* AnalyticsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsService.swift; sourceTree = "<group>"; };
 		FE583F0D22AFC9F300EF3CDA /* FirebaseAnalyticsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseAnalyticsService.swift; sourceTree = "<group>"; };
@@ -141,6 +161,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B886FBA8E9E79013B5A50888 /* Pods_AcceptanceTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -148,6 +169,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C97486FDF4DD33D6425EB497 /* Pods_ios_base.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -157,6 +179,12 @@
 		506A29AE0C7D2BF634BD7D7D /* Pods */ = {
 			isa = PBXGroup;
 			children = (
+				21E8D96E1DA981F8FCCFCA2F /* Pods-AcceptanceTests.debug.xcconfig */,
+				CF081D39C34A81D13D22BBB6 /* Pods-AcceptanceTests.staging.xcconfig */,
+				E263A8A07D838EC4E08EEAA8 /* Pods-AcceptanceTests.release.xcconfig */,
+				A902D431CC715BF283E3AFB2 /* Pods-ios-base.debug.xcconfig */,
+				ED0AC0190D101803F661CBAE /* Pods-ios-base.staging.xcconfig */,
+				30ACA6104514E285F2B715F4 /* Pods-ios-base.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -164,6 +192,7 @@
 		9B0C72511C738C3100BAF3B1 /* ios-base */ = {
 			isa = PBXGroup;
 			children = (
+				FE4D635A22B2C74700685161 /* Navigators */,
 				FE583F0822AFC9D300EF3CDA /* Analytics */,
 				9BFA84EE1C7767D9009F64E4 /* Model */,
 				9BAFB7BC2114CA8D0099DC61 /* View */,
@@ -231,6 +260,7 @@
 				9B5AFADB1C7205EC002347D6 /* Products */,
 				9B0C72511C738C3100BAF3B1 /* ios-base */,
 				506A29AE0C7D2BF634BD7D7D /* Pods */,
+				DD9ABB916C316E444F6EB36A /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -273,6 +303,7 @@
 				FA54D5871E11C59600F0DBEA /* FirstViewController.swift */,
 				9B3AA3981ED35007005A4D26 /* SignInViewController.swift */,
 				9B3AA39A1ED35013005A4D26 /* SignUpViewController.swift */,
+				FE4D636122B2CBB000685161 /* OnboardingRoutes.swift */,
 			);
 			path = Onboarding;
 			sourceTree = "<group>";
@@ -281,6 +312,7 @@
 			isa = PBXGroup;
 			children = (
 				9B3AA3A01ED4D014005A4D26 /* HomeViewController.swift */,
+				FE4D635F22B2CB3800685161 /* HomeRoutes.swift */,
 			);
 			path = Home;
 			sourceTree = "<group>";
@@ -326,6 +358,7 @@
 			children = (
 				9BAFB7C12114E3A80099DC61 /* Home */,
 				9BAFB7C02114E39C0099DC61 /* Onboarding */,
+				FE4D636322B2CDF700685161 /* ViewModelState.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -406,6 +439,15 @@
 			path = Services;
 			sourceTree = "<group>";
 		};
+		DD9ABB916C316E444F6EB36A /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				CAD50CF945C0577C5D464B48 /* Pods_AcceptanceTests.framework */,
+				AB8D84D08CE7E8109E57D429 /* Pods_ios_base.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		E8290BFB1D832D4100599960 /* CustomControls */ = {
 			isa = PBXGroup;
 			children = (
@@ -431,6 +473,15 @@
 			path = Extensions;
 			sourceTree = "<group>";
 		};
+		FE4D635A22B2C74700685161 /* Navigators */ = {
+			isa = PBXGroup;
+			children = (
+				FE4D635B22B2C75400685161 /* Navigator.swift */,
+				FE4D635D22B2CAFF00685161 /* AppNavigator.swift */,
+			);
+			path = Navigators;
+			sourceTree = "<group>";
+		};
 		FE583F0822AFC9D300EF3CDA /* Analytics */ = {
 			isa = PBXGroup;
 			children = (
@@ -449,9 +500,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 9B2BF7331EBB9AB5001638C4 /* Build configuration list for PBXNativeTarget "AcceptanceTests" */;
 			buildPhases = (
+				05E8DDF5B81096FA828DC012 /* [CP] Check Pods Manifest.lock */,
 				9B2BF7251EBB9AB5001638C4 /* Sources */,
 				9B2BF7261EBB9AB5001638C4 /* Frameworks */,
 				9B2BF7271EBB9AB5001638C4 /* Resources */,
+				0F5E50061C95854CEE293C34 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -467,11 +520,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 9B5AFAEC1C7205EC002347D6 /* Build configuration list for PBXNativeTarget "ios-base" */;
 			buildPhases = (
+				B546317E6FBFE783247EC848 /* [CP] Check Pods Manifest.lock */,
 				9B5AFAD61C7205EB002347D6 /* Sources */,
 				9B5AFAD71C7205EB002347D6 /* Frameworks */,
 				9B5AFAD81C7205EB002347D6 /* Resources */,
 				9B22F5581C720E7D003DDCD8 /* ShellScript */,
 				FE583F0222AEDC6F00EF3CDA /* Crashlytics */,
+				549065D701FBB832243A35A2 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -555,6 +610,86 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		05E8DDF5B81096FA828DC012 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-AcceptanceTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		0F5E50061C95854CEE293C34 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-AcceptanceTests/Pods-AcceptanceTests-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/KIF/KIF.framework",
+				"${BUILT_PRODUCTS_DIR}/OHHTTPStubs/OHHTTPStubs.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/KIF.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OHHTTPStubs.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-AcceptanceTests/Pods-AcceptanceTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		549065D701FBB832243A35A2 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-ios-base/Pods-ios-base-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/Alamofire/Alamofire.framework",
+				"${BUILT_PRODUCTS_DIR}/Bolts/Bolts.framework",
+				"${BUILT_PRODUCTS_DIR}/Device/Device.framework",
+				"${BUILT_PRODUCTS_DIR}/FBSDKCoreKit/FBSDKCoreKit.framework",
+				"${BUILT_PRODUCTS_DIR}/FBSDKLoginKit/FBSDKLoginKit.framework",
+				"${BUILT_PRODUCTS_DIR}/GoogleUtilities/GoogleUtilities.framework",
+				"${BUILT_PRODUCTS_DIR}/IQKeyboardManagerSwift/IQKeyboardManagerSwift.framework",
+				"${BUILT_PRODUCTS_DIR}/Moya/Moya.framework",
+				"${BUILT_PRODUCTS_DIR}/RSFontSizes/RSFontSizes.framework",
+				"${BUILT_PRODUCTS_DIR}/Result/Result.framework",
+				"${BUILT_PRODUCTS_DIR}/nanopb/nanopb.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Alamofire.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Bolts.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Device.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FBSDKCoreKit.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FBSDKLoginKit.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GoogleUtilities.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/IQKeyboardManagerSwift.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Moya.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RSFontSizes.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Result.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/nanopb.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ios-base/Pods-ios-base-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		9B22F5581C720E7D003DDCD8 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -567,6 +702,28 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "if which swiftlint >/dev/null; then\nswiftlint\nelse\necho \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
+		B546317E6FBFE783247EC848 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-ios-base-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
 		};
 		FE583F0222AEDC6F00EF3CDA /* Crashlytics */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -613,12 +770,15 @@
 				FEE8080E22A6BB4F00743D1B /* APIError.swift in Sources */,
 				E8B30E021E72FF8000131DCF /* UIStoryboardExtension.swift in Sources */,
 				FE583F0E22AFC9F300EF3CDA /* FirebaseAnalyticsService.swift in Sources */,
+				FE4D636022B2CB3800685161 /* HomeRoutes.swift in Sources */,
 				9B3AA3A11ED4D014005A4D26 /* HomeViewController.swift in Sources */,
 				9B77E0751E2FB66F0020E450 /* UserDataManager.swift in Sources */,
 				9BD01E361F01641E007255E3 /* DictionaryExtension.swift in Sources */,
 				E8290C021D8330A800599960 /* StringExtension.swift in Sources */,
+				FE4D636222B2CBB000685161 /* OnboardingRoutes.swift in Sources */,
 				071CD2622228544700E6D385 /* FontExtension.swift in Sources */,
 				9B8D307020AB47E90050697F /* JSONEncodingExtension.swift in Sources */,
+				FE4D636422B2CDF700685161 /* ViewModelState.swift in Sources */,
 				E81171921DE5EFB7003D3DF5 /* UIViewControllerExtension.swift in Sources */,
 				9B3AA3991ED35007005A4D26 /* SignInViewController.swift in Sources */,
 				E8FBB1BF1DD21A32000D6740 /* Session.swift in Sources */,
@@ -635,9 +795,11 @@
 				9B0C72711C738D3400BAF3B1 /* AppDelegate.swift in Sources */,
 				FEE8080C22A6AE9900743D1B /* TargetType+Base.swift in Sources */,
 				FEE8080A22A6ACFF00743D1B /* APIService.swift in Sources */,
+				FE4D635C22B2C75400685161 /* Navigator.swift in Sources */,
 				FEE8081222A6D3FA00743D1B /* UserResource.swift in Sources */,
 				FE251D0722A7FE0F00E0DE90 /* DataExtension.swift in Sources */,
 				FE583F1022AFC9FA00EF3CDA /* AnalyticsEvent.swift in Sources */,
+				FE4D635E22B2CAFF00685161 /* AppNavigator.swift in Sources */,
 				E8FBB1C11DD21D18000D6740 /* SessionManager.swift in Sources */,
 				9BE3669F1F10175E007CAECD /* Base64Media.swift in Sources */,
 				9BAFB7C32114E3CD0099DC61 /* SignInViewModel.swift in Sources */,
@@ -682,6 +844,7 @@
 /* Begin XCBuildConfiguration section */
 		9B2BF7301EBB9AB5001638C4 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 21E8D96E1DA981F8FCCFCA2F /* Pods-AcceptanceTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ANALYZER_NONNULL = YES;
@@ -709,6 +872,7 @@
 		};
 		9B2BF7311EBB9AB5001638C4 /* Staging */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = CF081D39C34A81D13D22BBB6 /* Pods-AcceptanceTests.staging.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ANALYZER_NONNULL = YES;
@@ -729,6 +893,7 @@
 		};
 		9B2BF7321EBB9AB5001638C4 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = E263A8A07D838EC4E08EEAA8 /* Pods-AcceptanceTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ANALYZER_NONNULL = YES;
@@ -857,6 +1022,7 @@
 		};
 		9B5AFAED1C7205EC002347D6 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = A902D431CC715BF283E3AFB2 /* Pods-ios-base.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -884,6 +1050,7 @@
 		};
 		9B5AFAEE1C7205EC002347D6 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 30ACA6104514E285F2B715F4 /* Pods-ios-base.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -967,6 +1134,7 @@
 		};
 		9BEE614C1C736054002E43B2 /* Staging */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = ED0AC0190D101803F661CBAE /* Pods-ios-base.staging.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;

--- a/ios-base/AppDelegate.swift
+++ b/ios-base/AppDelegate.swift
@@ -30,11 +30,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     FBSDKApplicationDelegate.sharedInstance().application(application, didFinishLaunchingWithOptions: launchOptions)
     
     IQKeyboardManager.shared.enable = true
-    
-    if SessionManager.validSession {
-      let vc = UIStoryboard(name: "Main", bundle: nil).instantiateViewController(withIdentifier: "HomeViewController")
-      self.window?.rootViewController = vc
-    }
+
+    window = UIWindow(frame: UIScreen.main.bounds)
+    let rootVC = AppNavigator.shared.rootViewController
+    window?.rootViewController = rootVC
+    window?.makeKeyAndVisible()
     
     return true
   }

--- a/ios-base/AppDelegate.swift
+++ b/ios-base/AppDelegate.swift
@@ -20,6 +20,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
     return appD
   }()
+
   var window: UIWindow?
   
   func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
@@ -31,11 +32,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     
     IQKeyboardManager.shared.enable = true
 
-    window = UIWindow(frame: UIScreen.main.bounds)
     let rootVC = AppNavigator.shared.rootViewController
     window?.rootViewController = rootVC
-    window?.makeKeyAndVisible()
-    
+
     return true
   }
   
@@ -50,7 +49,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     //Take user to onboarding if needed, do NOT redirect the user if is already in the landing
     // to avoid losing the current VC stack state.
     if window?.rootViewController is HomeViewController {
-      window?.rootViewController = UIStoryboard(name: "Main", bundle: nil).instantiateInitialViewController()
+      AppNavigator.shared.navigate(to: OnboardingRoutes.firstScreen, with: .changeRoot)
     }
   }
   

--- a/ios-base/Base.lproj/Main.storyboard
+++ b/ios-base/Base.lproj/Main.storyboard
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="aXS-GV-C4h">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="aXS-GV-C4h">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
-        <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -29,7 +28,7 @@
         <!--First View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController extendedLayoutIncludesOpaqueBars="YES" automaticallyAdjustsScrollViewInsets="NO" id="BYZ-38-t0r" customClass="FirstViewController" customModule="ios_base" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="FirstViewController" extendedLayoutIncludesOpaqueBars="YES" automaticallyAdjustsScrollViewInsets="NO" useStoryboardIdentifierAsRestorationIdentifier="YES" id="BYZ-38-t0r" customClass="FirstViewController" customModule="ios_base" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="y3c-jy-aDJ"/>
                         <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
@@ -39,7 +38,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OVq-bX-pA7">
-                                <rect key="frame" x="86.5" y="474" width="201" height="45"/>
+                                <rect key="frame" x="87" y="474" width="201" height="45"/>
                                 <color key="backgroundColor" red="0.20000000000000001" green="0.20000000000000001" blue="0.20000000000000001" alpha="0.76094285102739723" colorSpace="calibratedRGB"/>
                                 <accessibility key="accessibilityConfiguration" identifier="GoToSignInButton"/>
                                 <constraints>
@@ -52,7 +51,7 @@
                                     <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
                                 <connections>
-                                    <segue destination="8qd-iW-5fg" kind="show" id="gzI-wi-lZU"/>
+                                    <action selector="signInTapped" destination="BYZ-38-t0r" eventType="touchUpInside" id="hOB-TC-Gqv"/>
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="EN8-2n-nei">
@@ -69,7 +68,7 @@
                                     <color key="titleColor" red="0.21931966145833334" green="0.21931966145833334" blue="0.21931966145833334" alpha="1" colorSpace="calibratedRGB"/>
                                 </state>
                                 <connections>
-                                    <segue destination="1Oa-ww-vdW" kind="show" id="RSH-lc-RaH"/>
+                                    <action selector="signUpTapped" destination="BYZ-38-t0r" eventType="touchUpInside" id="ujP-qo-Kgd"/>
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nMy-eR-RsW">
@@ -127,7 +126,7 @@ RS iOS BASE.</string>
         <!--Sign In View Controller-->
         <scene sceneID="ZQL-UK-H2d">
             <objects>
-                <viewController id="8qd-iW-5fg" customClass="SignInViewController" customModule="ios_base" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="SignInViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="8qd-iW-5fg" customClass="SignInViewController" customModule="ios_base" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="Dm9-Bd-t2A"/>
                         <viewControllerLayoutGuide type="bottom" id="uJs-A0-SPi"/>
@@ -217,7 +216,7 @@ RS iOS BASE.</string>
         <!--Home View Controller-->
         <scene sceneID="qZP-Pf-s6w">
             <objects>
-                <viewController storyboardIdentifier="HomeViewController" id="K4y-mn-w4p" customClass="HomeViewController" customModule="ios_base" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="HomeViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="K4y-mn-w4p" customClass="HomeViewController" customModule="ios_base" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="b07-nt-cIs"/>
                         <viewControllerLayoutGuide type="bottom" id="gRs-YP-uAr"/>
@@ -233,7 +232,7 @@ RS iOS BASE.</string>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aMM-gP-X0k">
-                                <rect key="frame" x="87" y="570" width="200" height="45"/>
+                                <rect key="frame" x="87.5" y="570" width="200" height="45"/>
                                 <color key="backgroundColor" red="0.69471571180555558" green="0.27205175823635525" blue="0.35792462901418848" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <accessibility key="accessibilityConfiguration" identifier="LogoutButton"/>
                                 <constraints>
@@ -283,7 +282,7 @@ RS iOS BASE.</string>
         <!--Sign Up View Controller-->
         <scene sceneID="D1s-zu-Y9Z">
             <objects>
-                <viewController id="1Oa-ww-vdW" customClass="SignUpViewController" customModule="ios_base" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="SignUpViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="1Oa-ww-vdW" customClass="SignUpViewController" customModule="ios_base" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="XMA-3Z-CBb"/>
                         <viewControllerLayoutGuide type="bottom" id="sxg-nY-nv5"/>
@@ -337,7 +336,7 @@ RS iOS BASE.</string>
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Sign Up" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AaK-dC-F7z">
-                                <rect key="frame" x="32" y="104" width="109.5" height="38.5"/>
+                                <rect key="frame" x="32" y="104" width="109" height="38.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="32"/>
                                 <color key="textColor" red="0.45508993310000001" green="0.41961441859999998" blue="0.40671423159999998" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>

--- a/ios-base/Info.plist
+++ b/ios-base/Info.plist
@@ -62,7 +62,7 @@
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
-	<string>Main</string>
+	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>

--- a/ios-base/Navigators/AppNavigator.swift
+++ b/ios-base/Navigators/AppNavigator.swift
@@ -1,0 +1,23 @@
+//
+//  AppNavigator.swift
+//  ios-base
+//
+//  Created by Mauricio Cousillas on 6/13/19.
+//  Copyright © 2019 TopTier labs. All rights reserved.
+//
+
+import Foundation
+
+class AppNavigator: BaseNavigator {
+  static let shared = AppNavigator()
+
+  init() {
+    let initialRoute: Route = SessionManager.validSession ?
+      HomeRoutes.home : OnboardingRoutes.firstScreen
+    super.init(with: initialRoute)
+  }
+
+  required init(with route: Route) {
+    super.init(with: route)
+  }
+}

--- a/ios-base/Navigators/Navigator.swift
+++ b/ios-base/Navigators/Navigator.swift
@@ -1,0 +1,204 @@
+//
+//  Navigator.swift
+//  ios-base
+//
+//  Created by Mauricio Cousillas on 6/13/19.
+//  Copyright © 2019 TopTier labs. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+/**
+ The base navigator class implements the navigator protocol
+ exposing basic behaviour extensible via inheritance.
+ For example, you should subclass if you want to add
+ some logic to the initial route by checking something
+ stored in your keychain.
+ */
+open class BaseNavigator: Navigator {
+  open var rootViewController: UINavigationController?
+  open var currentViewController: UIViewController?
+
+  public required init(with route: Route) {
+    let screen = route.screen
+    if let navigation = screen as? UINavigationController {
+      rootViewController = navigation
+    } else {
+      let viewController = screen
+      rootViewController = UINavigationController(rootViewController: viewController)
+      rootViewController?.isNavigationBarHidden = true
+      currentViewController = viewController
+    }
+  }
+}
+
+/**
+ The Navigator is the base of this framework, it handles all
+ your application navigation stack.
+ It keeps track of your root NavigationController and the
+ ViewController that is currently displayed. This way it can
+ handle any kind of navigation action that you might want to dispatch.
+ */
+public protocol Navigator: class {
+  /// The root navigation controller of your stack.
+  var rootViewController: UINavigationController? { get set }
+
+  /// The currently visible ViewController
+  var currentViewController: UIViewController? { get set }
+
+  /// Convencience init to set your application starting screen.
+  init(with route: Route)
+
+  /**
+   Navigate from your current screen to a new route.
+   - Parameters:
+   - route: The destination route of your navigation action.
+   - transition: The transition type that you want to use.
+   - animated: Animate the transition or not.
+   - completion: Completion handler.
+   */
+  func navigate(to route: Route, with transition: TransitionType, animated: Bool, completion: (() -> Void)?)
+
+  /**
+   Navigate from your current screen to a new entire navigator. Can only push a router as a modal. Afterwards, other controllers can be pushed inside the presented Navigator.
+   - Parameters:
+   - Navigator: The destination navigator that you want to navigate to
+   - animated: Animate the transition or not.
+   - completion: Completion handler.
+   */
+  func navigate(to router: Navigator, animated: Bool, completion: (() -> Void)?)
+
+  /**
+   Handles backwards navigation through the stack.
+   */
+  func pop(animated: Bool)
+
+  /**
+   Handles backwards navigation through the stack.
+   - Parameters:
+   - route: The index of the route of your navigation action.
+   - animated: Animate the transition or not.
+   */
+  func popTo(index: Int, animated: Bool)
+
+  /**
+   Handles backwards navigation through the stack.
+   - Parameters:
+   - route: The destination route of your navigation action.
+   - animated: Animate the transition or not.
+   */
+  func popTo(route: Route, animated: Bool)
+
+  /**
+   Dismiss your current ViewController.
+   - Parameters:
+   - animated: Animate the transition or not.
+   - completion: Completion handler.
+   */
+  func dismiss(animated: Bool, completion: (() -> Void)?)
+}
+
+public extension Navigator {
+  func navigate(to route: Route, with transition: TransitionType, animated: Bool = true, completion: (() -> Void)? = nil) {
+    let viewController = route.screen
+    switch transition {
+    case .modal:
+      currentViewController?.present(viewController, animated: animated, completion: completion)
+      currentViewController = viewController
+    case .push:
+      rootViewController?.pushViewController(viewController, animated: animated)
+      currentViewController = viewController
+    case .reset:
+      rootViewController?.setViewControllers([viewController], animated: animated)
+      currentViewController = viewController
+    case .changeRoot:
+      UIView.animate(withDuration: 0.3) { [weak self] in
+        if let navigation = (viewController as? UINavigationController) {
+          UIApplication.shared.keyWindow?.rootViewController = navigation
+          self?.rootViewController = navigation
+          self?.currentViewController = self?.rootViewController?.topViewController
+        } else {
+          let navigationController = UINavigationController(rootViewController: viewController)
+          UIApplication.shared.keyWindow?.rootViewController = navigationController
+          self?.rootViewController = navigationController
+          self?.rootViewController?.isNavigationBarHidden = true
+          self?.currentViewController = viewController
+        }
+      }
+    }
+  }
+
+  func navigate(to router: Navigator, animated: Bool, completion: (() -> Void)?) {
+    guard let viewController = router.rootViewController else {
+      assert(false, "Navigator does not have a root view controller")
+      return
+    }
+
+    currentViewController?.present(viewController, animated: animated, completion: completion)
+    currentViewController = viewController
+  }
+
+  func pop(animated: Bool = true) {
+    rootViewController?.popViewController(animated: animated)
+    currentViewController = rootViewController?.visibleViewController
+  }
+
+  func popToRoot(animated: Bool = true) {
+    rootViewController?.popToRootViewController(animated: animated)
+  }
+
+  func popTo(index: Int, animated: Bool = true) {
+    guard
+      let viewControllers = rootViewController?.viewControllers,
+      viewControllers.count > index
+      else { return }
+    let viewController = viewControllers[index]
+    rootViewController?.popToViewController(viewController, animated: animated)
+    currentViewController = viewController
+  }
+
+  func popTo(route: Route, animated: Bool = true) {
+    guard
+      let viewControllers = rootViewController?.viewControllers,
+      let viewController = viewControllers.first(where: {
+        type(of: $0) == type(of: route.screen)
+      })
+      else { return }
+    rootViewController?.popToViewController(viewController, animated: true)
+    currentViewController = viewController
+  }
+
+  func dismiss(animated: Bool = true, completion: (() -> Void)? = nil) {
+    let presentingViewController = currentViewController?.presentingViewController
+    currentViewController?.dismiss(animated: animated, completion: completion)
+    currentViewController = presentingViewController
+  }
+}
+
+/**
+ Protocol used to define a Route. The route contains
+ all the information necessary to instantiate it's screen.
+ For example, you could have a LoginRoute, that knows how
+ to instantiate it's viewModel, and also forward any
+ information that it's passed to the Route.
+ */
+public protocol Route {
+  // The screen that should be returned for that Route.
+  var screen: UIViewController { get }
+}
+
+/// Available Transition types for navigation actions.
+public enum TransitionType {
+  /// Presents the screen modally on top of the current ViewController
+  case modal
+
+  /// Pushes the next screen to the rootViewController navigation Stack.
+  case push
+
+  /// Resets the rootViewController navitationStack and set's the Route's screen as the initial view controller of the stack.
+  case reset
+
+  /// Replaces the key window's Root view controller with the Route's screen.
+  case changeRoot
+}

--- a/ios-base/Navigators/Navigator.swift
+++ b/ios-base/Navigators/Navigator.swift
@@ -205,12 +205,11 @@ public enum TransitionType {
 
 public extension UIViewController {
   func embedInNavigationController() -> UINavigationController {
-    if let navigation = (self as? UINavigationController) {
+    if let navigation = self as? UINavigationController {
       return navigation
-    } else {
-      let navigationController = UINavigationController(rootViewController: self)
-      navigationController.isNavigationBarHidden = true
-      return navigationController
     }
+    let navigationController = UINavigationController(rootViewController: self)
+    navigationController.isNavigationBarHidden = true
+    return navigationController
   }
 }

--- a/ios-base/Navigators/Navigator.swift
+++ b/ios-base/Navigators/Navigator.swift
@@ -23,9 +23,7 @@ open class BaseNavigator: Navigator {
   }
 
   public required init(with route: Route) {
-    let screen = route.screen
-    let navigation = screen.embedInNavigationController()
-    rootViewController = navigation
+    rootViewController = route.screen.embedInNavigationController()
   }
 }
 

--- a/ios-base/View/Home/HomeRoutes.swift
+++ b/ios-base/View/Home/HomeRoutes.swift
@@ -1,0 +1,27 @@
+//
+//  HomeRoutes.swift
+//  ios-base
+//
+//  Created by Mauricio Cousillas on 6/13/19.
+//  Copyright © 2019 TopTier labs. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+enum HomeRoutes: Route {
+  case home
+
+  var screen: UIViewController {
+    switch self {
+    case .home:
+      guard let home = UIStoryboard
+        .instantiateViewController(HomeViewController.self)
+      else {
+        return UIViewController()
+      }
+      home.viewModel = HomeViewModel()
+      return home
+    }
+  }
+}

--- a/ios-base/View/Home/HomeViewController.swift
+++ b/ios-base/View/Home/HomeViewController.swift
@@ -15,7 +15,7 @@ class HomeViewController: UIViewController {
   @IBOutlet weak var welcomeLabel: UILabel!
   @IBOutlet weak var logOut: UIButton!
   
-  var viewModel = HomeViewModel()
+  var viewModel: HomeViewModel!
   
   // MARK: - Lifecycle Events
   override func viewDidLoad() {
@@ -46,9 +46,6 @@ extension HomeViewController: HomeViewModelDelegate {
     case .error(let errorDescription):
       UIApplication.hideNetworkActivity()
       print(errorDescription)
-    case .loggedOut:
-      UIApplication.hideNetworkActivity()
-      UIApplication.shared.keyWindow?.rootViewController = self.storyboard?.instantiateInitialViewController()
     }
   }
 }

--- a/ios-base/View/Onboarding/FirstViewController.swift
+++ b/ios-base/View/Onboarding/FirstViewController.swift
@@ -16,7 +16,7 @@ class FirstViewController: UIViewController {
   @IBOutlet weak var signIn: UIButton!
   @IBOutlet weak var signUp: UIButton!
   
-  var viewModel = FirstViewModel()
+  var viewModel: FirstViewModel!
 
   // MARK: - Lifecycle
   
@@ -36,6 +36,14 @@ class FirstViewController: UIViewController {
   @IBAction func facebookLogin() {
     viewModel.facebookLogin()
   }
+
+  @IBAction func signInTapped() {
+    viewModel.signIn()
+  }
+
+  @IBAction func signUpTapped() {
+    viewModel.signUp()
+  }
 }
 
 extension FirstViewController: FirstViewModelDelegate {
@@ -48,9 +56,6 @@ extension FirstViewController: FirstViewModelDelegate {
     case .error(let errorDescription):
       UIApplication.hideNetworkActivity()
       showMessage(title: "Oops", message: errorDescription)
-    case .facebookLoggedIn:
-      UIApplication.hideNetworkActivity()
-      performSegue(withIdentifier: "goToMainView", sender: nil)
     }
   }
 }

--- a/ios-base/View/Onboarding/OnboardingRoutes.swift
+++ b/ios-base/View/Onboarding/OnboardingRoutes.swift
@@ -17,29 +17,41 @@ enum OnboardingRoutes: Route {
   var screen: UIViewController {
     switch self {
     case .firstScreen:
-      guard let first = UIStoryboard
-        .instantiateViewController(FirstViewController.self)
-      else {
-        return UIViewController()
-      }
-      first.viewModel = FirstViewModel()
-      return first
+      return buildFirstViewController()
     case .signIn:
-      guard let signIn = UIStoryboard
-        .instantiateViewController(SignInViewController.self)
-      else {
-        return UIViewController()
-      }
-      signIn.viewModel = SignInViewModelWithCredentials()
-      return signIn
+      return buildSignInViewController()
     case .signUp:
-      guard let signUp = UIStoryboard
-        .instantiateViewController(SignUpViewController.self)
+      return buildSignUpViewController()
+    }
+  }
+
+  private func buildSignInViewController() -> UIViewController {
+    guard let signIn = UIStoryboard
+      .instantiateViewController(SignInViewController.self)
       else {
         return UIViewController()
-      }
-      signUp.viewModel = SignUpViewModelWithEmail()
-      return signUp
     }
+    signIn.viewModel = SignInViewModelWithCredentials()
+    return signIn
+  }
+
+  private func buildSignUpViewController() -> UIViewController {
+    guard let signUp = UIStoryboard
+      .instantiateViewController(SignUpViewController.self)
+      else {
+        return UIViewController()
+    }
+    signUp.viewModel = SignUpViewModelWithEmail()
+    return signUp
+  }
+
+  private func buildFirstViewController() -> UIViewController {
+    guard let first = UIStoryboard
+      .instantiateViewController(FirstViewController.self)
+      else {
+        return UIViewController()
+    }
+    first.viewModel = FirstViewModel()
+    return first
   }
 }

--- a/ios-base/View/Onboarding/OnboardingRoutes.swift
+++ b/ios-base/View/Onboarding/OnboardingRoutes.swift
@@ -1,0 +1,45 @@
+//
+//  OnboardingRoutes.swift
+//  ios-base
+//
+//  Created by Mauricio Cousillas on 6/13/19.
+//  Copyright © 2019 TopTier labs. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+enum OnboardingRoutes: Route {
+  case firstScreen
+  case signIn
+  case signUp
+
+  var screen: UIViewController {
+    switch self {
+    case .firstScreen:
+      guard let first = UIStoryboard
+        .instantiateViewController(FirstViewController.self)
+      else {
+        return UIViewController()
+      }
+      first.viewModel = FirstViewModel()
+      return first
+    case .signIn:
+      guard let signIn = UIStoryboard
+        .instantiateViewController(SignInViewController.self)
+      else {
+        return UIViewController()
+      }
+      signIn.viewModel = SignInViewModelWithCredentials()
+      return signIn
+    case .signUp:
+      guard let signUp = UIStoryboard
+        .instantiateViewController(SignUpViewController.self)
+      else {
+        return UIViewController()
+      }
+      signUp.viewModel = SignUpViewModelWithEmail()
+      return signUp
+    }
+  }
+}

--- a/ios-base/View/Onboarding/SignInViewController.swift
+++ b/ios-base/View/Onboarding/SignInViewController.swift
@@ -16,7 +16,7 @@ class SignInViewController: UIViewController {
   @IBOutlet weak var emailField: UITextField!
   @IBOutlet weak var passwordField: UITextField!
   
-  var viewModel = SignInViewModelWithCredentials()
+  var viewModel: SignInViewModelWithCredentials!
   
   // MARK: - Lifecycle Events
   
@@ -49,11 +49,6 @@ class SignInViewController: UIViewController {
     viewModel.login()
   }
   
-  func setLoggedInRoot() {
-    let homeVC = self.storyboard?.instantiateViewController(withIdentifier: "HomeViewController") as? HomeViewController
-    UIApplication.shared.keyWindow?.rootViewController = homeVC
-  }
-  
   func setLoginButton(enabled: Bool) {
     logIn.alpha = enabled ? 1 : 0.5
     logIn.isEnabled = enabled
@@ -72,9 +67,6 @@ extension SignInViewController: SignInViewModelDelegate {
     case .error(let errorDescription):
       UIApplication.hideNetworkActivity()
       showMessage(title: "Error", message: errorDescription)
-    case .loggedIn:
-      UIApplication.hideNetworkActivity()
-      setLoggedInRoot()
     case .idle:
       UIApplication.hideNetworkActivity()
     }

--- a/ios-base/View/Onboarding/SignUpViewController.swift
+++ b/ios-base/View/Onboarding/SignUpViewController.swift
@@ -17,7 +17,7 @@ class SignUpViewController: UIViewController {
   @IBOutlet weak var passwordField: UITextField!
   @IBOutlet weak var passwordConfirmationField: UITextField!
   
-  var viewModel = SignUpViewModelWithEmail()
+  var viewModel: SignUpViewModelWithEmail!
   
   // MARK: - Lifecycle Events
   
@@ -52,11 +52,6 @@ class SignUpViewController: UIViewController {
     viewModel.signup()
   }
   
-  func setSignedUpRoot() {
-    let homeVC = self.storyboard?.instantiateViewController(withIdentifier: "HomeViewController") as? HomeViewController
-    UIApplication.shared.keyWindow?.rootViewController = homeVC
-  }
-  
   func setSignUpButton(enabled: Bool) {
     signUp.alpha = enabled ? 1 : 0.5
     signUp.isEnabled = enabled
@@ -72,9 +67,6 @@ extension SignUpViewController: SignUpViewModelDelegate {
     switch viewModel.state {
     case .loading:
       UIApplication.showNetworkActivity()
-    case .signedUp:
-      UIApplication.hideNetworkActivity()
-      setSignedUpRoot()
     case .error(let errorDescription):
       UIApplication.hideNetworkActivity()
       showMessage(title: "Error", message: errorDescription)

--- a/ios-base/ViewModel/Home/HomeViewModel.swift
+++ b/ios-base/ViewModel/Home/HomeViewModel.swift
@@ -8,13 +8,6 @@
 
 import Foundation
 
-enum HomeViewModelState: Equatable {
-  case loading
-  case error(String)
-  case idle
-  case loggedOut
-}
-
 protocol HomeViewModelDelegate: class {
   func didUpdateState()
 }
@@ -25,9 +18,9 @@ class HomeViewModel {
   
   var userEmail: String?
   
-  var state: HomeViewModelState = .idle {
+  var state: ViewModelState = .idle {
     didSet {
-        delegate?.didUpdateState()
+      delegate?.didUpdateState()
     }
   }
   
@@ -44,7 +37,8 @@ class HomeViewModel {
   func logoutUser() {
     state = .loading
     UserService.sharedInstance.logout({ [weak self] in
-      self?.state = .loggedOut
+      self?.state = .idle
+      AppNavigator.shared.navigate(to: OnboardingRoutes.firstScreen, with: .changeRoot)
     }, failure: { [weak self] error in
       self?.state = .error(error.localizedDescription)
     })

--- a/ios-base/ViewModel/Onboarding/FirstViewModel.swift
+++ b/ios-base/ViewModel/Onboarding/FirstViewModel.swift
@@ -9,20 +9,13 @@
 import Foundation
 import FBSDKLoginKit
 
-enum FirstViewModelState {
-  case loading
-  case error(String)
-  case idle
-  case facebookLoggedIn
-}
-
 protocol FirstViewModelDelegate: class {
   func didUpdateState()
 }
 
 class FirstViewModel {
   
-  var state: FirstViewModelState = .idle {
+  var state: ViewModelState = .idle {
     didSet {
       delegate?.didUpdateState()
     }
@@ -43,6 +36,14 @@ class FirstViewModel {
                          from: viewController,
                          handler: checkFacebookLoginRequest)
   }
+
+  func signIn() {
+    AppNavigator.shared.navigate(to: OnboardingRoutes.signIn, with: .push)
+  }
+
+  func signUp() {
+    AppNavigator.shared.navigate(to: OnboardingRoutes.signUp, with: .push)
+  }
   
   // MARK: Facebook callback methods
   
@@ -54,7 +55,8 @@ class FirstViewModel {
     //This fails with 404 since this endpoint is not implemented in the API base
     UserService.sharedInstance.loginWithFacebook(token: FBSDKAccessToken.current().tokenString,
                               success: { [weak self] in
-                                self?.state = .facebookLoggedIn
+                                self?.state = .idle
+                                AppNavigator.shared.navigate(to: HomeRoutes.home, with: .changeRoot)
                               },
                               failure: { [weak self] error in
                                 self?.state = .error(error.localizedDescription)

--- a/ios-base/ViewModel/Onboarding/SignInViewModel.swift
+++ b/ios-base/ViewModel/Onboarding/SignInViewModel.swift
@@ -8,13 +8,6 @@
 
 import Foundation
 
-enum SignInViewModelState: Equatable {
-  case loading
-  case idle
-  case error(String)
-  case loggedIn
-}
-
 protocol SignInViewModelDelegate: class {
   func didUpdateCredentials()
   func didUpdateState()
@@ -22,7 +15,7 @@ protocol SignInViewModelDelegate: class {
 
 class SignInViewModelWithCredentials {
   
-  var state: SignInViewModelState = .idle {
+  var state: ViewModelState = .idle {
     didSet {
       delegate?.didUpdateState()
     }
@@ -53,9 +46,10 @@ class SignInViewModelWithCredentials {
              password: password,
              success: { [weak self] in
               guard let self = self else { return }
-              self.state = .loggedIn
+              self.state = .idle
               AnalyticsManager.shared.identifyUser(with: self.email)
               AnalyticsManager.shared.log(event: Event.login)
+              AppNavigator.shared.navigate(to: HomeRoutes.home, with: .changeRoot)
              },
              failure: { [weak self] error in
                self?.state = .error(error.localizedDescription)

--- a/ios-base/ViewModel/Onboarding/SignUpViewModel.swift
+++ b/ios-base/ViewModel/Onboarding/SignUpViewModel.swift
@@ -9,13 +9,6 @@
 import Foundation
 import UIKit
 
-enum SignUpViewModelState {
-  case loading
-  case idle
-  case error(String)
-  case signedUp
-}
-
 protocol SignUpViewModelDelegate: class {
   func formDidChange()
   func didUpdateState()
@@ -23,7 +16,7 @@ protocol SignUpViewModelDelegate: class {
 
 class SignUpViewModelWithEmail {
   
-  var state: SignUpViewModelState = .idle {
+  var state: ViewModelState = .idle {
     didSet {
       delegate?.didUpdateState()
     }
@@ -59,9 +52,10 @@ class SignUpViewModelWithEmail {
                    avatar64: UIImage.random(),
                    success: { [weak self] in
                     guard let self = self else { return }
-                    self.state = .signedUp
+                    self.state = .idle
                     AnalyticsManager.shared.identifyUser(with: self.email)
                     AnalyticsManager.shared.log(event: Event.registerSuccess(email: self.email))
+                    AppNavigator.shared.navigate(to: HomeRoutes.home, with: .changeRoot)
                    },
                    failure: { [weak self] error in
                     if let apiError = error as? APIError {

--- a/ios-base/ViewModel/ViewModelState.swift
+++ b/ios-base/ViewModel/ViewModelState.swift
@@ -1,0 +1,15 @@
+//
+//  ViewModelState.swift
+//  ios-base
+//
+//  Created by Mauricio Cousillas on 6/13/19.
+//  Copyright © 2019 TopTier labs. All rights reserved.
+//
+
+import Foundation
+
+enum ViewModelState: Equatable {
+  case loading
+  case error(String)
+  case idle
+}


### PR DESCRIPTION
#### Description:

* Added helpers and basic structure to handle navigation programatically, without the need of using segues.

### Advantages
- No more storyboard segues 🎉 
- One centralized place to initialise your views and viewModels.
- Separation of concerns, the view does not need to know how to init a viewModel, and the viewModel does not need to know about its view.
- Separates the view from the responsability of handling the navigation stack and leaves that to the routes and navigators.
- Reproducible view setups (if you push to the same view from 3 screens, you don't need to repeat the config in the segue).

### Imeplementation details
* The main implementation is in the `Navigator.swift` file, which implements the base behavior for a Navigation.
* Then, The `Route` protocol defines a basic interface to create a UIViewController, your `Routes` are the ones in charge of Creating the UIViewController instance and wire it up with it's corresponding viewModel. Check `OnboardingRoutes` or `HomeRoutes` for examples.
* Semantically, A Navigator is in charge of one NavigationStack. So for example, you will have an `AppNavigator` that manages your root navigation stack for your app and then you could have extra navigator for other flows such as a modal flow that is isolated, or one for each tab on a tabViewController.

