### PR TITLE
Fix: API Service

### DIFF
--- a/ios-base/Networking/APIService.swift
+++ b/ios-base/Networking/APIService.swift
@@ -121,7 +121,7 @@ open class BaseApiService<T>: APIService where T: TargetType {
 
       switch result {
       case let .success(moyaResponse):
-        onSuccess(moyaResponse)
+        self.handleSuccess(with: moyaResponse, onSuccess: onSuccess, onFailure: onFailure)
       case let .failure(error):
         self.handleError(with: error, onFailure)
       }
@@ -142,6 +142,19 @@ open class BaseApiService<T>: APIService where T: TargetType {
                                                    failsOnEmptyData: true)
 
       onSuccess(decodedResult, filteredResponse)
+    } catch let error {
+      handleError(with: error, onFailure)
+    }
+  }
+  
+  private func handleSuccess(
+    with response: Response,
+    onSuccess: @escaping (_ response: Response) -> Void,
+    onFailure: ((Error, Response?) -> Void)? = nil
+  ) {
+    do {
+      let filteredResponse = try response.filterSuccessfulStatusCodes()
+      onSuccess(filteredResponse)
     } catch let error {
       handleError(with: error, onFailure)
     }

--- a/ios-base/Networking/TargetType+Base.swift
+++ b/ios-base/Networking/TargetType+Base.swift
@@ -48,7 +48,10 @@ extension TargetType {
     return Self.baseHeaders
   }
 
-  public func requestParameters(parameters: [String: Any], encoding: ParameterEncoding = JSONEncoding.default) -> Task {
+  public func requestParameters(
+    parameters: [String: Any],
+    encoding: ParameterEncoding = JSONEncoding.default
+  ) -> Task {
     return .requestParameters(parameters: parameters, encoding: encoding)
   }
 

--- a/ios-base/Networking/TargetType+Base.swift
+++ b/ios-base/Networking/TargetType+Base.swift
@@ -48,8 +48,8 @@ extension TargetType {
     return Self.baseHeaders
   }
 
-  public func requestParameters(parameters: [String: Any]) -> Task {
-    return .requestParameters(parameters: parameters, encoding: JSONEncoding.default)
+  public func requestParameters(parameters: [String: Any], encoding: ParameterEncoding = JSONEncoding.default) -> Task {
+    return .requestParameters(parameters: parameters, encoding: encoding)
   }
 
   public func multipartData(


### PR DESCRIPTION
#### Description:

For requests where we are not parsing the response, the `onSuccess` callback is always being called. This is because of how Moya works (a `404` server response is successful for Moya), and to solve this we must filter successful responses.

---

#### Notes:

* I also added support for URL params in the `requestParameters` function because it was confusing for an external dev. I know that we can call Moya's `requestParameters` function directly to pass another encoding, but since we are providing a helper there is no harm in covering other cases other than JSON encoding and leaving it as the default param.

Closes #143 