### PR TITLE
Add pre-build actions scripts

### DIFF
--- a/ios-base.xcodeproj/xcshareddata/xcschemes/ios-base-develop.xcscheme
+++ b/ios-base.xcodeproj/xcshareddata/xcschemes/ios-base-develop.xcscheme
@@ -10,7 +10,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Run Script"
-               scriptText = "&#10;">
+               scriptText = "/usr/libexec/PlistBuddy -c &quot;Set :ConfigurationName \&quot;$CONFIGURATION\&quot;&quot; &quot;$PROJECT_DIR/$INFOPLIST_FILE&quot;&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/ios-base.xcodeproj/xcshareddata/xcschemes/ios-base-production.xcscheme
+++ b/ios-base.xcodeproj/xcshareddata/xcschemes/ios-base-production.xcscheme
@@ -10,7 +10,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Run Script"
-               scriptText = "&#10;">
+               scriptText = "/usr/libexec/PlistBuddy -c &quot;Set :ConfigurationName \&quot;$CONFIGURATION\&quot;&quot; &quot;$PROJECT_DIR/$INFOPLIST_FILE&quot;&#10;&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"

--- a/ios-base.xcodeproj/xcshareddata/xcschemes/ios-base-staging.xcscheme
+++ b/ios-base.xcodeproj/xcshareddata/xcschemes/ios-base-staging.xcscheme
@@ -10,7 +10,7 @@
             ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
             <ActionContent
                title = "Run Script"
-               scriptText = "&#10;">
+               scriptText = "/usr/libexec/PlistBuddy -c &quot;Set :ConfigurationName \&quot;$CONFIGURATION\&quot;&quot; &quot;$PROJECT_DIR/$INFOPLIST_FILE&quot;&#10;&#10;">
                <EnvironmentBuildable>
                   <BuildableReference
                      BuildableIdentifier = "primary"


### PR DESCRIPTION
#### Description:

* Adds missing pre-build action scripts to set the current build configuration
This is needed to fetch the correct keys from the ThirdPartyKeys.plist.

